### PR TITLE
h264nal: disable building tests by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,12 +23,16 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 endif()
 
-enable_testing()
+
 
 # Recurse into source code subdirectories.
 add_subdirectory(src)
 add_subdirectory(tools)
-add_subdirectory(test)
+option(BUILD_TESTS "Build h264 gtests" ON)
+if(BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(test)
+endif()
 
 option(BUILD_CLANG_FUZZER "Build clang fuzzer sanitizer targets" ON)
 


### PR DESCRIPTION
This is avoid build failures when building liblcvm when gtest is not installed and also to speed up the build process , when needed user has to do "CC=gcc CXX=g++ cmake -DBUILD_CLANG_FUZZER=OFF -DBUILD_H264_TESTS=ON .."