### PR TITLE
h264nal: improve the build compatibility with AOSP build

### DIFF
--- a/include/h264_common.h
+++ b/include/h264_common.h
@@ -13,8 +13,6 @@
 
 #include "rtc_common.h"
 
-#undef P_ALL
-
 namespace h264nal {
 
 // Table 7-1 of the 2012 standard.
@@ -61,6 +59,11 @@ enum NalUnitType : uint8_t {
 
 bool IsNalUnitTypeReserved(uint32_t nal_unit_type);
 bool IsNalUnitTypeUnspecified(uint32_t nal_unit_type);
+
+// P_ALL is defined in <sys/wait.h> in POSIX systems
+#ifdef P_ALL
+#undef P_ALL
+#endif
 
 // Table 7-3
 enum SliceType : uint8_t {

--- a/include/h264_common.h
+++ b/include/h264_common.h
@@ -13,6 +13,8 @@
 
 #include "rtc_common.h"
 
+#undef P_ALL
+
 namespace h264nal {
 
 // Table 7-1 of the 2012 standard.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,6 @@
 
 option(H264NAL_SMALL_FOOTPRINT, "xmall footprint build")
 
-add_definitions(-D__STDC_FORMAT_MACROS)
-
 if(H264NAL_SMALL_FOOTPRINT)
   message(STATUS "src: small footprint selected")
   add_compile_definitions(SMALL_FOOTPRINT)
@@ -74,6 +72,26 @@ else()
       h264_nal_unit_parser.cc
 )
 endif()
+
+# Add __STDC_FORMAT_MACROS to files that require it
+set_source_files_properties(
+  h264_dec_ref_pic_marking_parser.cc
+  h264_hrd_parameters_parser.cc
+  h264_pps_parser.cc
+  h264_pred_weight_table_parser.cc
+  h264_prefix_nal_unit_parser.cc
+  h264_ref_pic_list_modification_parser.cc
+  h264_slice_header_in_scalable_extension_parser.cc
+  h264_slice_header_parser.cc
+  h264_slice_layer_extension_rbsp_parser.cc
+  h264_slice_layer_without_partitioning_rbsp_parser.cc
+  h264_sps_extension_parser.cc
+  h264_sps_parser.cc
+  h264_subset_sps_parser.cc
+  h264_vui_parameters_parser.cc
+  PROPERTIES
+  COMPILE_DEFINITIONS __STDC_FORMAT_MACROS
+)
 
 target_include_directories(h264nal PUBLIC ../include/)
 if (WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 option(H264NAL_SMALL_FOOTPRINT, "xmall footprint build")
 
+add_definitions(-D__STDC_FORMAT_MACROS)
+
 if(H264NAL_SMALL_FOOTPRINT)
   message(STATUS "src: small footprint selected")
   add_compile_definitions(SMALL_FOOTPRINT)

--- a/src/h264_dec_ref_pic_marking_parser.cc
+++ b/src/h264_dec_ref_pic_marking_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_dec_ref_pic_marking_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_hrd_parameters_parser.cc
+++ b/src/h264_hrd_parameters_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_hrd_parameters_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_pps_parser.cc
+++ b/src/h264_pps_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_pps_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_pred_weight_table_parser.cc
+++ b/src/h264_pred_weight_table_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_pred_weight_table_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_prefix_nal_unit_parser.cc
+++ b/src/h264_prefix_nal_unit_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_prefix_nal_unit_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_ref_pic_list_modification_parser.cc
+++ b/src/h264_ref_pic_list_modification_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_ref_pic_list_modification_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_slice_header_in_scalable_extension_parser.cc
+++ b/src/h264_slice_header_in_scalable_extension_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_slice_header_in_scalable_extension_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_slice_header_parser.cc
+++ b/src/h264_slice_header_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_slice_header_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_slice_layer_extension_rbsp_parser.cc
+++ b/src/h264_slice_layer_extension_rbsp_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_slice_layer_extension_rbsp_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_slice_layer_without_partitioning_rbsp_parser.cc
+++ b/src/h264_slice_layer_without_partitioning_rbsp_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_slice_layer_without_partitioning_rbsp_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_sps_extension_parser.cc
+++ b/src/h264_sps_extension_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_sps_extension_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_sps_parser.cc
+++ b/src/h264_sps_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_sps_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_subset_sps_parser.cc
+++ b/src/h264_subset_sps_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_subset_sps_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 

--- a/src/h264_vui_parameters_parser.cc
+++ b/src/h264_vui_parameters_parser.cc
@@ -4,7 +4,6 @@
 
 #include "h264_vui_parameters_parser.h"
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <stdio.h>
 


### PR DESCRIPTION
Two changes were made to improve build compatibility with AOSP:
1. STDC_FORMAT_MACROS is predefined in the AOSP build. Therefore, the #define __STDC_FORMAT_MACROS directive has been moved from each individual .cc file to the CMakeLists.txt file to prevent redefinition of this macro.
2. Added #undef P_ALL in h264_common.h because this macro conflicts with a macro defined in an Android system file.