### PR TITLE
h264nal: improve the build compatibility with AOSP build

### DIFF
--- a/include/h264_common.h
+++ b/include/h264_common.h
@@ -60,6 +60,11 @@ enum NalUnitType : uint8_t {
 bool IsNalUnitTypeReserved(uint32_t nal_unit_type);
 bool IsNalUnitTypeUnspecified(uint32_t nal_unit_type);
 
+// P_ALL is defined in <sys/wait.h> in POSIX systems
+#ifdef P_ALL
+#undef P_ALL
+#endif
+
 // Table 7-3
 enum SliceType : uint8_t {
   P = 0,


### PR DESCRIPTION
h264nal: improve the build compatibility with AOSP build

add the code below to h264_common.h to address the build error under AOSP
``` // P_ALL is defined in <sys/wait.h> in POSIX systems
#ifdef P_ALL
#undef P_ALL
#endif 
```

Tested:
```$ make test
Running tests...
Test project /Users/zhoujian/Documents/Tools/fork/h264nal/build
      Start  1: h264_common_unittest
 1/23 Test  #1: h264_common_unittest .........................................   Passed    0.01 sec
      Start  2: h264_hrd_parameters_parser_unittest
 2/23 Test  #2: h264_hrd_parameters_parser_unittest ..........................   Passed    0.01 sec
      Start  3: h264_vui_parameters_parser_unittest
 3/23 Test  #3: h264_vui_parameters_parser_unittest ..........................   Passed    0.01 sec
      Start  4: h264_sps_parser_unittest
 4/23 Test  #4: h264_sps_parser_unittest .....................................   Passed    0.00 sec
      Start  5: h264_pps_parser_unittest
 5/23 Test  #5: h264_pps_parser_unittest .....................................   Passed    0.01 sec
      Start  6: h264_ref_pic_list_modification_parser_unittest
 6/23 Test  #6: h264_ref_pic_list_modification_parser_unittest ...............   Passed    0.01 sec
      Start  7: h264_pred_weight_table_parser_unittest
 7/23 Test  #7: h264_pred_weight_table_parser_unittest .......................   Passed    0.01 sec
      Start  8: h264_dec_ref_pic_marking_parser_unittest
 8/23 Test  #8: h264_dec_ref_pic_marking_parser_unittest .....................   Passed    0.00 sec
      Start  9: h264_rtp_single_parser_unittest
 9/23 Test  #9: h264_rtp_single_parser_unittest ..............................   Passed    0.01 sec
      Start 10: h264_rtp_stapa_parser_unittest
10/23 Test #10: h264_rtp_stapa_parser_unittest ...............................   Passed    0.01 sec
      Start 11: h264_rtp_fua_parser_unittest
11/23 Test #11: h264_rtp_fua_parser_unittest .................................   Passed    0.01 sec
      Start 12: h264_rtp_parser_unittest
12/23 Test #12: h264_rtp_parser_unittest .....................................   Passed    0.01 sec
      Start 13: h264_slice_header_parser_unittest
13/23 Test #13: h264_slice_header_parser_unittest ............................   Passed    0.01 sec
      Start 14: h264_slice_header_in_scalable_extension_parser_unittest
14/23 Test #14: h264_slice_header_in_scalable_extension_parser_unittest ......   Passed    0.01 sec
      Start 15: h264_slice_layer_without_partitioning_rbsp_parser_unittest
15/23 Test #15: h264_slice_layer_without_partitioning_rbsp_parser_unittest ...   Passed    0.01 sec
      Start 16: h264_slice_layer_extension_rbsp_parser_unittest
16/23 Test #16: h264_slice_layer_extension_rbsp_parser_unittest ..............   Passed    0.01 sec
      Start 17: h264_sps_extension_parser_unittest
17/23 Test #17: h264_sps_extension_parser_unittest ...........................   Passed    0.01 sec
      Start 18: h264_subset_sps_parser_unittest
18/23 Test #18: h264_subset_sps_parser_unittest ..............................   Passed    0.01 sec
      Start 19: h264_sps_svc_extension_parser_unittest
19/23 Test #19: h264_sps_svc_extension_parser_unittest .......................   Passed    0.01 sec
      Start 20: h264_bitstream_parser_unittest
20/23 Test #20: h264_bitstream_parser_unittest ...............................   Passed    0.01 sec
      Start 21: h264_prefix_nal_unit_parser_unittest
21/23 Test #21: h264_prefix_nal_unit_parser_unittest .........................   Passed    0.01 sec
      Start 22: h264_nal_unit_header_svc_extension_parser_unittest
22/23 Test #22: h264_nal_unit_header_svc_extension_parser_unittest ...........   Passed    0.01 sec
      Start 23: h264_nal_unit_parser_unittest
23/23 Test #23: h264_nal_unit_parser_unittest ................................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 23

```